### PR TITLE
Fix gcc compiler warnings on linux

### DIFF
--- a/src_generators/boxblur.cpp
+++ b/src_generators/boxblur.cpp
@@ -33,8 +33,8 @@ IntensityMap BoxBlur::calculate(IntensityMap input, int radius, bool tileable) {
     int kernelPixelAmount = (2 * radius + 1) * (2 * radius + 1);
 
     #pragma omp parallel for  // OpenMP
-    for(int y = 0; y < input.getHeight(); y++) {
-        for(int x = 0; x < input.getWidth(); x++) {
+    for(size_t y = 0; y < input.getHeight(); y++) {
+        for(size_t x = 0; x < input.getWidth(); x++) {
             float sum = 0.0;
 
             //blur kernel loops

--- a/src_generators/gaussianblur.cpp
+++ b/src_generators/gaussianblur.cpp
@@ -68,7 +68,7 @@ std::vector<double> GaussianBlur::boxesForGauss(double sigma, int n) {
 }
 
 void GaussianBlur::boxBlur(IntensityMap &input, IntensityMap &result, double radius, bool tileable) {
-    for(int i = 0; i < input.getWidth() * input.getHeight(); i++) {
+    for(size_t i = 0; i < input.getWidth() * input.getHeight(); i++) {
         result.setValue(i, input.at(i));
     }
 

--- a/src_generators/intensitymap.cpp
+++ b/src_generators/intensitymap.cpp
@@ -119,8 +119,8 @@ size_t IntensityMap::getHeight() const {
 
 void IntensityMap::invert() {
     #pragma omp parallel for
-    for(int y = 0; y < this->getHeight(); y++) {
-        for(int x = 0; x < this->getWidth(); x++) {
+    for(size_t y = 0; y < this->getHeight(); y++) {
+        for(size_t x = 0; x < this->getWidth(); x++) {
             const double inverted = 1.0 - this->map.at(y).at(x);
             this->map.at(y).at(x) = inverted;
         }
@@ -130,10 +130,10 @@ void IntensityMap::invert() {
 QImage IntensityMap::convertToQImage() const {
     QImage result(this->getWidth(), this->getHeight(), QImage::Format_ARGB32);
 
-    for(int y = 0; y < this->getHeight(); y++) {
+    for(size_t y = 0; y < this->getHeight(); y++) {
         QRgb *scanline = (QRgb*) result.scanLine(y);
 
-        for(int x = 0; x < this->getWidth(); x++) {
+        for(size_t x = 0; x < this->getWidth(); x++) {
             const int c = 255 * map.at(y).at(x);
             scanline[x] = qRgba(c, c, c, 255);
         }

--- a/src_gui/clickablelabel.h
+++ b/src_gui/clickablelabel.h
@@ -17,7 +17,7 @@ signals:
     void clicked();
     
 protected:
-    void mousePressEvent(QMouseEvent* event) { 
+    void mousePressEvent(QMouseEvent *) {
         emit clicked(); 
     }
 };

--- a/src_gui/graphicsscene.cpp
+++ b/src_gui/graphicsscene.cpp
@@ -36,12 +36,3 @@ GraphicsScene::GraphicsScene(qreal x, qreal y, qreal width, qreal height, QObjec
     : QGraphicsScene(x, y, width, height, parent)
 {
 }
-
-void GraphicsScene::dragEnterEvent(QGraphicsSceneDragDropEvent *event) {
-}
-
-void GraphicsScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event) {
-}
-
-void GraphicsScene::dropEvent(QGraphicsSceneDragDropEvent *event) {
-}

--- a/src_gui/graphicsscene.h
+++ b/src_gui/graphicsscene.h
@@ -30,9 +30,6 @@ public:
     GraphicsScene(QObject *parent = 0);
     GraphicsScene(const QRectF &sceneRect, QObject *parent = 0);
     GraphicsScene(qreal x, qreal y, qreal width, qreal height, QObject *parent = 0);
-    void dragEnterEvent(QGraphicsSceneDragDropEvent *event);
-    void dragMoveEvent(QGraphicsSceneDragDropEvent* event);
-    void dropEvent(QGraphicsSceneDragDropEvent* event);
 };
 
 #endif // MYQGRAPHICSSCENE_H

--- a/src_gui/mainwindow.cpp
+++ b/src_gui/mainwindow.cpp
@@ -1055,7 +1055,7 @@ void MainWindow::hideAdvancedSettings() {
     connect(ui->checkBox_advanced_normal, SIGNAL(clicked(bool)), ui->label_method_normal, SLOT(setVisible(bool)));
 }
 
-void MainWindow::closeEvent(QCloseEvent* event) {
+void MainWindow::closeEvent(QCloseEvent *) {
     writeSettings();
 }
 


### PR DESCRIPTION
Removes unused functions.
Uses size_t for map height/width iterations.

Signed-off-by: Daniel Danzberger <daniel@dd-wrt.com>